### PR TITLE
Encode the handle.

### DIFF
--- a/common/settings/index.js
+++ b/common/settings/index.js
@@ -75,13 +75,14 @@ function shopHasInfo(shop) {
 
 function getShopifySingleLink(payload, type) {
   if (!payload.onlineStoreUrl) {
+    let handle = encodeURI(payload.handle);
     return (
       'https://' +
       wpshopify.settings.connection.storefront.domain +
       '/' +
       type +
       '/' +
-      payload.handle
+      handle
     );
   }
 


### PR DESCRIPTION
The handle contained in the onlineStoreURI property has already been encoded.
To achieve the same state as the case where onlineStoreURI cannot be obtained, a handle needs to be encoded.